### PR TITLE
fix: candidates were always undefined / type error on get

### DIFF
--- a/demo/test.ts
+++ b/demo/test.ts
@@ -6,3 +6,14 @@ const newSudoku = sudokuTools.generator.generate(62,true,true);
 
 console.log("##### New sudoku with solution created:");
 console.log(newSudoku);
+
+if (typeof newSudoku !== 'string') {
+   const candidates = SudokuTools(false).getCandidates.get(newSudoku.board);
+
+   if (candidates) {
+      console.log("##### Pencil candidates:");
+      candidates.forEach((row) => {
+         console.log(row.join(', '));
+      });
+   }
+}

--- a/src/components/get-candidates.ts
+++ b/src/components/get-candidates.ts
@@ -17,7 +17,7 @@ export default class SudokuGetCandidates {
       }
     }
 
-    get(board:string): Array<string>|boolean {
+    get(board:string): Array<string[]>|false {
       this.log("Getting all candidates");
         /* Return all possible candidatees for each square as a grid of
             candidates, returnning `false` if a contradiction is encountered.
@@ -43,10 +43,10 @@ export default class SudokuGetCandidates {
         }
     
         // Transform candidates map into grid
-        const rows = [];
+        const rows: string[][] = [];
         let cur_row = [];
         let i = 0;
-        for (const square in Object.keys(candidates_map)) {
+        for (const square of Object.keys(candidates_map)) {
           const candidates = candidates_map[square];
           cur_row.push(candidates);
           if (i % 9 == 8) {


### PR DESCRIPTION
Fixes two issues:

1) tools.getCandidates.get always returned undefined[][] because of the
   wrong array iteration keyword

2) the return type on tools.getCandidates.get was wrong, saying it
   returned string[], but it actually returned string[][]

Also improves tools.getCandidates.get by changing the return type to use
true instead of boolean. This helps because you can now just say
`if (candidates)` instead of needing a type check. This is demonstrated
in the demo/test.ts file, which now calls getCandidates so that it's
easy to see if the fixes ever regress.